### PR TITLE
Fix slashes in regex validation example

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -415,9 +415,9 @@ export default function ApiRefTable({ tabIndex }: any) {
     register({
       pattern: ${
         isStandard
-          ? "\\[A-Za-z]{3}\\"
+          ? "/[A-Za-z]{3}/"
           : `{
-        value: \\[A-Za-z]{3}\\,
+        value: /[A-Za-z]{3}/,
         message: 'error message'
       }`
       }


### PR DESCRIPTION
Just a quick fix, noticed this whilst looking at the validation docs.