### PR TITLE
fix(example): fix bug in defaultExample

### DIFF
--- a/src/components/codeExamples/defaultExample.ts
+++ b/src/components/codeExamples/defaultExample.ts
@@ -16,7 +16,7 @@ function YourForm() {
       {/* include validation with required or other standard HTML validation rules */}
       <input name="exampleRequired" ref={register({ required: true })} />
       {/* errors will return when field validation fails  */}
-      {errors.example && '<span>This field is required</span>'}
+      {errors.exampleRequired && <span>This field is required</span>}
       
       <input type="submit" />
     </form>


### PR DESCRIPTION
Great library/site!

I was playing around with the examples and noticed there is a small issue with the code for the default example (first one here: https://react-hook-form.com/get-started). 

The two issues are:
1. The error object is checking the wrong field for errors (checking errors from the `example` field, not the `exampleRequired` field)
2. The error `span`, is being rendered a string instead of html. 

This fixes both of those issues. 

Thanks!